### PR TITLE
Add a comment to point to https://github.com/jumpingrivers/meetingsR

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -2,7 +2,7 @@
 title = "Events"
 +++
 
-<!-- Please consider adding your event https://github.com/jumpingrivers/meetingsR -->
+<!-- Please consider adding your event to  https://github.com/jumpingrivers/meetingsR -->
 
 # Future
 * [Paris 2019](https://paris2019.satrdays.org/) - February 23th

--- a/content/events.md
+++ b/content/events.md
@@ -2,6 +2,8 @@
 title = "Events"
 +++
 
+<!-- Please consider adding your event https://github.com/jumpingrivers/meetingsR -->
+
 # Future
 * [Paris 2019](https://paris2019.satrdays.org/) - February 23th
 * [Los Angeles 2019](http://losangeles2019.satrdays.org) - April 6th

--- a/content/faq.en.md
+++ b/content/faq.en.md
@@ -14,15 +14,14 @@ SatRdays are held all over the globe. You can see where events are happening -- 
 There's so many ways you can get involved. If you're a techy who can contribute coding experience, we always need a hand developing our infrastructure. If you want to share your knowledge, why not put forward a session at an event near you. If you want to make the event near you a success, you can help organise it and make it run smoothly on the day by volunteering. If you want to run an event near you, let us know. Come talk to us on [Slack](https://join.slack.com/t/rusergroups/shared_invite/enQtMjEyNDA3MzcyMjczLTE3NWEzNjQ3MjZiMWM0OGE2ZWFiZDliNTY4NTJjYWY1NGNjMmNlNDUzNzkzOTZmMDBjYjRiZjFhNjk4MDY0ZGY)
 
 ## 4. WHO FUNDS SATRDAYS?
-The [R Consortium](https://r-consortium.org) helped us setup and continue to support us.The Consortium is filled with companies doing great things for or with R. They're investing in growing the community and the support for the R language. Other fine companies are also getting involved by sponsoring or supporting local events.
+The [R Consortium](https://r-consortium.org) helped us setup and continue to support us. The Consortium is filled with companies doing great things for or with R. They're investing in growing the community and the support for the R language. Other fine companies are also getting involved by sponsoring or supporting local events.
 
 ## 5. HOW CAN I ORGANISE A SATRDAY?
 If you'd like to rganise a satRday read about whats involved via our [knowledgebase](//knowledgebase.satrdays.org) or come talk to us on [Slack](https://join.slack.com/t/rusergroups/shared_invite/enQtMjEyNDA3MzcyMjczLTE3NWEzNjQ3MjZiMWM0OGE2ZWFiZDliNTY4NTJjYWY1NGNjMmNlNDUzNzkzOTZmMDBjYjRiZjFhNjk4MDY0ZGY) if you'd like to organise an event.
 
 ## 6. WHAT OTHER R EVENTS ARE OUT THERE?
-- Find a local user group with this handy [directory](http://blog.revolutionanalytics.com/local-r-groups.html) from Revolution Analytics (now known as Microsoft!)
+- Find a local user group or conference with this handy [directory](https://jumpingrivers.github.io/meetingsR/) from [Jumping Rivers](https://www.jumpingrivers.com)
 - There's [R-Ladies](https://rladies.org/) events
-- There's conferences
 
 ## 7. WHAT MAKES SATRDAYS SO SPECIAL?
 It depends who you ask! For some it's the local organisers, others the ability to learn from great speakers in your own time, and for others it's open platform for growing the community.


### PR DESCRIPTION
Feel free to reject this PR. 

Just now I try to add any SatRdays events to https://github.com/jumpingrivers/meetingsR, but sometimes I miss some. It would be nice if organisers just did it themselves.